### PR TITLE
Quote identifiers with backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ select/multi_select/status → nœuds `(:NotionOption {id,name,color,property})`
 
 relation → arêtes `(page)-[:REL__{prop}]->(page) (MERGE le nœud cible par id).`
 
-Toutes les clés/labels/relations sont assainis pour Cypher (sanitizeProp/Rel/Label). Les chaînes sont échappées.
+Les labels, relations et noms de propriété sont entourés de backticks (les backticks internes sont doublés). Les chaînes sont échappées.
 Limitations
 
 *    Ne gère pas les rollups et quelques types exotiques non listés.


### PR DESCRIPTION
## Summary
- Replace separate quote helpers with a single `quote` that doubles internal backticks
- Use the unified helper for labels, relationship types, and property keys
- Document that identifiers are backtick-quoted and internal backticks are escaped

## Testing
- `cabal build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed/403)*
- `apt-get install -y cabal-install` *(fails: unable to locate package)*
- `stack build` *(fails: command not found)*
- `nix build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1b4da8408321b5c8a1723e562ffd