### PR TITLE
feat: add Docker image build target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,21 @@
         haskellPackages = pkgs.haskellPackages;
         notion-to-memgraph = haskellPackages.callCabal2nix "notion-to-memgraph" ./. {};
       in {
-        packages.default = notion-to-memgraph;
+        packages = {
+          default = notion-to-memgraph;
+          dockerImage = pkgs.dockerTools.buildImage {
+            name = "notion-to-memgraph";
+            copyToRoot = pkgs.buildEnv {
+              name = "image-root";
+              paths = [ notion-to-memgraph ];
+              pathsToLink = [ "/bin" ];
+            };
+            config = {
+              Cmd = [ "/bin/notion-to-memgraph-web" ];
+              ExposedPorts = { "8080/tcp" = {}; };
+            };
+          };
+        };
         devShells.default = pkgs.mkShell {
           inputsFrom = [ notion-to-memgraph ];
         };


### PR DESCRIPTION
## Summary
- add docker image target to flake outputs

## Testing
- `nix build .#dockerImage` *(fails: `bash: command not found: nix`)*
- `apt-get update` *(fails: repository InRelease is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cb3fc974832197bdf5c1578a56fb