### PR TITLE
Wrap JSON output in statements structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Entrée depuis un fichier ou stdin. Label par défaut: NotionPage.
 
 `cat notion_query.json | cabal run notion-to-memgraph -- --label MyPage > graph.cypher`
 
-Ajoutez `--json` pour obtenir un tableau JSON de requêtes Cypher sans point-virgule :
+Ajoutez `--json` pour obtenir un objet JSON de la forme `{"statements": [{"statement": "MATCH (n) RETURN n;"}]}` :
 
 ```
 cat notion_query.json | cabal run notion-to-memgraph -- --json > queries.json
@@ -38,7 +38,7 @@ cabal run notion-to-memgraph-web
 Envoyez une requête `POST` avec le JSON Notion sur `http://localhost:8080/?label=MonLabel`
 pour recevoir la requête Cypher en réponse.
 
-Ajoutez `json=1` à l'URL pour une réponse `application/json` contenant un tableau de requêtes :
+Ajoutez `json=1` à l'URL pour une réponse `application/json` de la forme `{"statements": [{"statement": "..."}]}` :
 
 ```
 curl -XPOST 'http://localhost:8080/?json=1' --data @notion_query.json

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import           Options.Applicative
-import           Data.Aeson (eitherDecode, encode)
+import           Data.Aeson (eitherDecode, encode, object, (.=))
 import           Notion.Model
 import           Transform
 
@@ -29,5 +29,8 @@ main = do
     Left e -> fail e
     Right dq ->
       if asJSON
-        then BL.putStr $ encode (transformToCypherList label dq)
+        then
+          let stmts = transformToCypherList label dq
+              stmtObjs = map (\s -> object ["statement" .= T.snoc s ';']) stmts
+          in BL.putStr $ encode (object ["statements" .= stmtObjs])
         else TIO.putStrLn $ transformToCypher label dq

--- a/app/Web.hs
+++ b/app/Web.hs
@@ -8,7 +8,7 @@ import           Data.Maybe (fromMaybe, isJust)
 import           Network.Wai (Application, Request, Response, responseLBS, requestMethod, queryString, strictRequestBody)
 import           Network.Wai.Handler.Warp (run)
 import           Network.HTTP.Types (status200, status400, methodPost)
-import           Data.Aeson (eitherDecode, encode)
+import           Data.Aeson (eitherDecode, encode, object, (.=))
 import           Transform (transformToCypher, transformToCypherList)
 import           Notion.Model (DatabaseQuery)
 
@@ -33,7 +33,9 @@ app req respond
           if asJSON
             then
               let cyphers = transformToCypherList label (dq :: DatabaseQuery)
-              in respond $ responseLBS status200 [("Content-Type", "application/json")] (encode cyphers)
+                  stmtObjs = map (\c -> object ["statement" .= T.snoc c ';']) cyphers
+                  body = encode (object ["statements" .= stmtObjs])
+              in respond $ responseLBS status200 [("Content-Type", "application/json")] body
             else
               let cypher = transformToCypher label (dq :: DatabaseQuery)
               in respond $ responseLBS status200 [("Content-Type", "text/plain")] (BL.fromStrict $ TE.encodeUtf8 cypher)


### PR DESCRIPTION
## Summary
- Wrap JSON mode responses in `{ "statements": [{"statement": ...}] }`
- Document new JSON response structure

## Testing
- `cabal build` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b3599b50148321ab085be121c40ce7